### PR TITLE
List available ports in macOS

### DIFF
--- a/Sources/SwiftSerial/SerialPort.swift
+++ b/Sources/SwiftSerial/SerialPort.swift
@@ -276,7 +276,7 @@ public actor SerialPort {
     #if os(OSX)
     /**
      List all available serial ports.
-     - Returns: A list of available serial ports.
+     - Returns: A String array containing the paths to all available serial ports.
      */
     public static func listAvailablePorts() throws -> [String] {
         let task = Process()


### PR DESCRIPTION
Only in macOS, get a String array containing all the paths to all available serial ports. 

```swift
let ports = try SerialPort.listAvailablePorts()
let serial = SerialPort(path: ports[0])
```